### PR TITLE
fix: set code preview tab size to 4 (#98)

### DIFF
--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -34,8 +34,10 @@ const highlighter = (code: string) => {
 .prism-editor__editor {
   white-space: pre !important;
   width: 0px !important;
+  tab-size: 4 !important;
 }
 .prism-editor__container {
   overflow-x: scroll !important;
+  tab-size: 4;
 }
 </style>


### PR DESCRIPTION
Resolve #98 

Set code preview tab size to 4.

> It appears that the code preview tab size was intended to be set to 4 previously, but something broke. See https://github.com/Normal-OJ/new-front-end/commit/95b1fc1cc2c2aa58bd70ed44729c84b31faa5a3e#diff-9b321e04143a8982c26ed7a7ea3e54fe0c0f4a694332cf96d001813b2425e1c7L25