### PR TITLE
feat: add btn to download all submissions in course

### DIFF
--- a/src/auto/components.d.ts
+++ b/src/auto/components.d.ts
@@ -29,6 +29,7 @@ declare module '@vue/runtime-core' {
     IUilConstructor: typeof import('~icons/uil/constructor')['default']
     IUilEdit: typeof import('~icons/uil/edit')['default']
     IUilFacebook: typeof import('~icons/uil/facebook')['default']
+    IUilFileDownload: typeof import('~icons/uil/file-download')['default']
     IUilFileExclamationAlt: typeof import('~icons/uil/file-exclamation-alt')['default']
     IUilFileUploadAlt: typeof import('~icons/uil/file-upload-alt')['default']
     IUilFilterSlash: typeof import('~icons/uil/filter-slash')['default']


### PR DESCRIPTION
Add a button to download all submissions in a course.
The professor would like a way to check if two account are sharing a same IP address to find cheater.
I think the search needs a whole redesign if we want these kind of feature.
I think downloading all submissions is sufficient enough for now.