### PR TITLE
feat: center course navbar when the screen is wider

### DIFF
--- a/src/auto/components.d.ts
+++ b/src/auto/components.d.ts
@@ -26,6 +26,7 @@ declare module '@vue/runtime-core' {
     IUilChartLine: typeof import('~icons/uil/chart-line')['default']
     IUilCheck: typeof import('~icons/uil/check')['default']
     IUilCheckCircle: typeof import('~icons/uil/check-circle')['default']
+    IUilClock: typeof import('~icons/uil/clock')['default']
     IUilConstructor: typeof import('~icons/uil/constructor')['default']
     IUilEdit: typeof import('~icons/uil/edit')['default']
     IUilFacebook: typeof import('~icons/uil/facebook')['default']

--- a/src/components/CourseSideBar.vue
+++ b/src/components/CourseSideBar.vue
@@ -47,7 +47,7 @@ const navs = [
     </li>
   </ul>
   <div v-else class="scrollbar-hide w-full overflow-scroll">
-    <div class="tabs w-max">
+    <div class="tabs mx-auto w-max">
       <template v-for="{ name, path } in navs">
         <a
           class="tab tab-bordered h-10 w-32"


### PR DESCRIPTION
On #159, the menu bar was redesigned for smaller screen. 
But it doesn't look that good on in-between screen size.
Made navbar centered to make it looks a bit nicer.
<img width="849" alt="image" src="https://github.com/Normal-OJ/new-front-end/assets/31620109/6dd81fad-7e5d-4da8-bf64-6e1162388ca5">
