### PR TITLE
fix : Update dockerfile version to support pnpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 RUN corepack enable
 
-RUN corepack prepare pnpm@8.6.5 --activate
-
 ENV VITE_APP_API_BASE_URL "http://localhost:8080/api"
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14-alpine
+FROM node:22-alpine
 
 ENV PNPM_HOME="/pnpm"
 


### PR DESCRIPTION
The current dockerfile uses `node:16.14-alpine` as the source to build the docker compose.
However, the project uses `pnpm@8.6.5` as its pnpm version, which is conflicted and cannot be run with node 16,
causes error when building docker compose.

Therefore, this pull request aims to modify the dockerfile to `node:22-alpine` as the source for docker compose,
which solve the error and make itself to work normally.

On the other hand, I remove the `corepack prepare pnpm@8.6.5` in dockerfile since the pnpm attributions have been set in `package.json`