### PR TITLE
fix: handle error happened in uploading new problem testdata

### DIFF
--- a/src/pages/course/[name]/problem/new.vue
+++ b/src/pages/course/[name]/problem/new.vue
@@ -68,17 +68,20 @@ async function submit() {
     try {
       await api.Problem.modifyTestdata(problemId, testdataForm);
     } catch (error) {
-      alert("Problem created, but testdata upload failed.");
+      const errorMsg =
+        axios.isAxiosError(error) && error.response?.data?.message
+          ? error.response.data.message
+          : "Unknown error occurred :(";
+      alert(`Problem created, but testdata upload failed: ${errorMsg}`);
       router.push(`/course/${route.params.name}/problem/${problemId}/edit`);
       throw error;
     }
     router.push(`/course/${route.params.name}/problem/${problemId}`);
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.data?.message) {
-      formElement.value.errorMsg = error.response.data.message;
-    } else {
-      formElement.value.errorMsg = "Unknown error occurred :(";
-    }
+    formElement.value.errorMsg =
+      axios.isAxiosError(error) && error.response?.data?.message
+        ? error.response.data.message
+        : "Unknown error occurred :(";
     throw error;
   } finally {
     formElement.value.isLoading = false;

--- a/src/pages/course/[name]/problem/new.vue
+++ b/src/pages/course/[name]/problem/new.vue
@@ -63,10 +63,15 @@ async function submit() {
       })
     ).data;
 
-    // TODO: additional handling if testcase upload fail
     const testdataForm = new FormData();
     testdataForm.append("case", testdata.value);
-    await api.Problem.modifyTestdata(problemId, testdataForm);
+    try {
+      await api.Problem.modifyTestdata(problemId, testdataForm);
+    } catch (error) {
+      alert("Problem created, but testdata upload failed.");
+      router.push(`/course/${route.params.name}/problem/${problemId}/edit`);
+      throw error;
+    }
     router.push(`/course/${route.params.name}/problem/${problemId}`);
   } catch (error) {
     if (axios.isAxiosError(error) && error.response?.data?.message) {


### PR DESCRIPTION
show a specific alert to provide info about the testdata failed to user, and then redirect to problem edit page to avoid re-creating new problems in the same page

For details, please see #179

Fix #179

Please see the video:
https://github.com/user-attachments/assets/a86c698a-49df-4db7-84b3-a789673606dd

